### PR TITLE
Add file header for ELPA compatibility

### DIFF
--- a/misc/slime-annot.el
+++ b/misc/slime-annot.el
@@ -1,3 +1,12 @@
+;;; slime-annot.el --- cl-annot support for SLIME
+
+;; URL: https://github.com/arielnetworks/cl-annot
+;; Package-Requires: ((slime "0"))
+
+;;; Commentary:
+
+;;; Code:
+
 (require 'cl)
 (require 'slime)
 
@@ -36,3 +45,5 @@
     (setq ad-return-value (list (point) (cadr ad-return-value)))))
 
 (provide 'slime-annot)
+
+;;; slime-annot.el ends here


### PR DESCRIPTION
This commit makes `slime-annot.el` installable with package.el.

For information about this fix, See following GNU Emacs Manual:
- [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)
