### PR TITLE
@export-structure on structures with docstrings

### DIFF
--- a/src/main/utils.lisp
+++ b/src/main/utils.lisp
@@ -127,7 +127,11 @@ with name, lambda-list and the body as arguments."
   "Return class-specifiers of CLASS-DEFINITION-FORM."
   (case (first class-definition-form)
     (defclass (nth 3 (progn-form-last class-definition-form)))
-    (defstruct (nthcdr 2 (progn-form-last class-definition-form)))))
+    (defstruct (if (stringp (nth 2 (progn-form-last class-definition-form)))
+		   ;; There's a documentation string, fetch the slots after it
+		   (nthcdr 3 (progn-form-last class-definition-form))
+		   ;; There's no documentation string, fetch the slots
+		   (nthcdr 2 (progn-form-last class-definition-form))))))
 
 (defun replace-slot-specifiers (function class-definition-form)
   "Replace slot-specifiers of CLASS-DEFINITION-FORM with FUNCTION. The


### PR DESCRIPTION
export-structure doesn't work on defstructs with docstrings

The slot-specifiers definition has been changed to make it work