### PR TITLE
Add '(in-package :cl-user)' at the top of CL files

### DIFF
--- a/src/lib/class.lisp
+++ b/src/lib/class.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.class
   (:nicknames :annot.class)
   (:use :cl

--- a/src/lib/doc.lisp
+++ b/src/lib/doc.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.doc
   (:nicknames :annot.doc)
   (:use :cl

--- a/src/lib/eval-when.lisp
+++ b/src/lib/eval-when.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.eval-when
   (:nicknames :annot.eval-when)
   (:use :cl)

--- a/src/lib/slot.lisp
+++ b/src/lib/slot.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.slot
   (:nicknames :annot.slot)
   (:use :cl

--- a/src/lib/std.lisp
+++ b/src/lib/std.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.std
   (:nicknames :annot.std)
   (:use :cl

--- a/src/main/annot.lisp
+++ b/src/main/annot.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot
   (:nicknames :annot)
   (:use :cl)

--- a/src/main/core.lisp
+++ b/src/main/core.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.core
   (:nicknames :annot.core)
   (:use :cl)

--- a/src/main/expand.lisp
+++ b/src/main/expand.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.expand
   (:nicknames :annot.expand)
   (:use :cl

--- a/src/main/helper.lisp
+++ b/src/main/helper.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.helper
   (:nicknames :annot.helper)
   (:use :cl

--- a/src/main/syntax.lisp
+++ b/src/main/syntax.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.syntax
   (:nicknames :annot.syntax)
   (:use :cl

--- a/src/main/utils.lisp
+++ b/src/main/utils.lisp
@@ -1,3 +1,4 @@
+(in-package :cl-user)
 (defpackage cl-annot.util
   (:nicknames :annot.util)
   (:use :cl)


### PR DESCRIPTION
The lacks cause `#<PACKAGE COMMON-LISP> is locked` error on CLISP.

```
INTERN("CL-ANNOT.UTIL"): #<PACKAGE COMMON-LISP> is lockedAn error occured while processing command line arguments
INTERN("CL-ANNOT.UTIL"): #<PACKAGE COMMON-LISP> is locked
```